### PR TITLE
Fix Sonic Frontiers cnvrs-text not working.

### DIFF
--- a/src/PuyoTextEditor/Formats/CnvrsTextTextAlignment.cs
+++ b/src/PuyoTextEditor/Formats/CnvrsTextTextAlignment.cs
@@ -24,5 +24,11 @@ namespace PuyoTextEditor.Formats
         /// </summary>
         [XmlEnum("right")]
         Right = 2,
+
+        /// <summary>
+        /// This is currently unknown. (first appeared in Sonic Frontiers)
+        /// </summary>
+        [XmlEnum("unknown")]
+        Unknown = 3,
     }
 }


### PR DESCRIPTION
This PR fixes cnvrs-text from Sonic Frontiers by adding a new value to the text alignment class.

Currently listed as unknown as I was unable to figure out what the value does. (from testing the most I got was the SEGA text on the title screen being misaligned)

Fixes #6.